### PR TITLE
Feature/safe close

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var client_1 = require("./lib/client");
-Object.defineProperty(exports, "Client", { enumerable: true, get: function () { return client_1.Client; } });
+exports.Client = client_1.Client;
 var stream_1 = require("./lib/stream");
-Object.defineProperty(exports, "Stream", { enumerable: true, get: function () { return stream_1.Stream; } });
+exports.Stream = stream_1.Stream;
 var common_1 = require("./lib/common");
-Object.defineProperty(exports, "URL", { enumerable: true, get: function () { return common_1.URL; } });
+exports.URL = common_1.URL;

--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -7,6 +7,7 @@ export declare class Client {
         rate_limit?: boolean;
     };
     private rate_limiter;
+    private _pendingProcesses;
     constructor(options?: {
         key?: string;
         secret?: string;
@@ -139,5 +140,6 @@ export declare class Client {
     getLastQuote(parameters: {
         symbol: string;
     }): Promise<LastQuoteResponse>;
+    close(): Promise<void>;
     private request;
 }

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Client = void 0;
 const node_fetch_1 = __importDefault(require("node-fetch"));
 const http_method_enum_1 = __importDefault(require("http-method-enum"));
 const qs_1 = __importDefault(require("qs"));
@@ -44,24 +43,41 @@ class Client {
             .catch(reject));
     }
     placeOrder(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.POST, common_1.URL.Account, `orders`, parameters)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.POST, common_1.URL.Account, `orders`, parameters)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     replaceOrder(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.PATCH, common_1.URL.Account, `orders/${parameters.order_id}`, parameters)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.PATCH, common_1.URL.Account, `orders/${parameters.order_id}`, parameters)
             .then(resolve)
             .catch(reject));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     cancelOrder(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `orders/${parameters.order_id}`)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `orders/${parameters.order_id}`)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     cancelOrders() {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `orders`)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `orders`)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     getPosition(parameters) {
         return new Promise((resolve, reject) => this.request(http_method_enum_1.default.GET, common_1.URL.Account, `positions/${parameters.symbol}`)
@@ -74,14 +90,24 @@ class Client {
             .catch(reject));
     }
     closePosition(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `positions/${parameters.symbol}`)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `positions/${parameters.symbol}`)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     closePositions() {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `positions`)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `positions`)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     getAsset(parameters) {
         return new Promise((resolve, reject) => this.request(http_method_enum_1.default.GET, common_1.URL.Account, `assets/${parameters.asset_id_or_symbol}`)
@@ -104,29 +130,54 @@ class Client {
             .catch(reject));
     }
     createWatchlist(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.POST, common_1.URL.Account, `watchlists`, parameters)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.POST, common_1.URL.Account, `watchlists`, parameters)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     updateWatchlist(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.PUT, common_1.URL.Account, `watchlists/${parameters.uuid}`, parameters)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.PUT, common_1.URL.Account, `watchlists/${parameters.uuid}`, parameters)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     addToWatchlist(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.POST, common_1.URL.Account, `watchlists/${parameters.uuid}`, parameters)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.POST, common_1.URL.Account, `watchlists/${parameters.uuid}`, parameters)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     removeFromWatchlist(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `watchlists/${parameters.uuid}/${parameters.symbol}`)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `watchlists/${parameters.uuid}/${parameters.symbol}`)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     deleteWatchlist(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `watchlists/${parameters.uuid}`)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.DELETE, common_1.URL.Account, `watchlists/${parameters.uuid}`)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     getCalendar(parameters) {
         return new Promise((resolve, reject) => this.request(http_method_enum_1.default.GET, common_1.URL.Account, `calendar?${qs_1.default.stringify(parameters)}`)
@@ -142,9 +193,14 @@ class Client {
             .catch(reject));
     }
     updateAccountConfigurations(parameters) {
-        return new Promise((resolve, reject) => this.request(http_method_enum_1.default.PATCH, common_1.URL.Account, `account/configurations`, parameters)
+        let transaction = new Promise((resolve, reject) => this.request(http_method_enum_1.default.PATCH, common_1.URL.Account, `account/configurations`, parameters)
             .then(resolve)
-            .catch(reject));
+            .catch(reject)
+            .finally(() => {
+            this._pendingProcesses.filter(p => p !== transaction);
+        }));
+        this._pendingProcesses.push(transaction);
+        return transaction;
     }
     getAccountActivities(parameters) {
         return new Promise((resolve, reject) => this.request(http_method_enum_1.default.GET, common_1.URL.Account, `account/activities/${parameters.activity_type}?${qs_1.default.stringify(parameters)}`)
@@ -174,6 +230,11 @@ class Client {
         return new Promise((resolve, reject) => this.request(http_method_enum_1.default.GET, common_1.URL.MarketData, `last_quote/stocks/${parameters.symbol}`)
             .then(resolve)
             .catch(reject));
+    }
+    //Allows all Promises to complete
+    close() {
+        return Promise.all(this._pendingProcesses)
+            .then(() => { });
     }
     request(method, url, endpoint, data) {
         // modify the base url if paper is true

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -47,7 +47,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -64,7 +64,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -74,7 +74,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -94,7 +94,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -104,7 +104,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -134,7 +134,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -144,7 +144,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -154,7 +154,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -164,7 +164,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -174,7 +174,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;
@@ -197,7 +197,7 @@ class Client {
             .then(resolve)
             .catch(reject)
             .finally(() => {
-            this._pendingProcesses.filter(p => p !== transaction);
+            this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         }));
         this._pendingProcesses.push(transaction);
         return transaction;

--- a/dist/lib/common.js
+++ b/dist/lib/common.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.URL = void 0;
 var URL;
 (function (URL) {
     URL["Account"] = "https://api.alpaca.markets/v2";

--- a/dist/lib/entities.js
+++ b/dist/lib/entities.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.WebSocketState = void 0;
 var WebSocketState;
 (function (WebSocketState) {
     WebSocketState["NOT_CONNECTED"] = "not_connected";

--- a/dist/lib/stream.js
+++ b/dist/lib/stream.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Stream = void 0;
 const ws_1 = __importDefault(require("ws"));
 const entities_1 = require("./entities");
 class Stream {

--- a/dist/test/client.js
+++ b/dist/test/client.js
@@ -206,3 +206,9 @@ ava_1.default('getLastQuote', async (test) => {
         .then(() => test.pass())
         .catch(test.fail);
 });
+ava_1.default('close', async (test) => {
+    await client
+        .close()
+        .then(() => test.pass())
+        .catch(() => test.fail());
+});

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -119,7 +119,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -156,7 +156,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -170,7 +170,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -200,7 +200,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -214,7 +214,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -274,7 +274,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -297,7 +297,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -319,7 +319,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -340,7 +340,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
     
@@ -354,7 +354,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -404,7 +404,7 @@ export class Client {
         .then(resolve)
         .catch(reject)
         .finally(() => {
-          this._pendingProcesses.filter(p => p !== transaction);
+          this._pendingProcesses = this._pendingProcesses.filter(p => p !== transaction);
         })
     )
 
@@ -501,7 +501,7 @@ export class Client {
         .catch(reject)
     )
   }
-  
+
   //Allows all Promises to complete
   close(): Promise<void> {
     return Promise.all(this._pendingProcesses)

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -2,7 +2,6 @@ import fetch from 'node-fetch'
 import method from 'http-method-enum'
 import qs from 'qs'
 import { RateLimiter } from 'limiter'
-
 import { URL } from './common'
 
 import {
@@ -23,7 +22,8 @@ import {
 } from './entities'
 
 export class Client {
-  private rate_limiter: RateLimiter = new RateLimiter(199, 'minute')
+  private rate_limiter: RateLimiter = new RateLimiter(199, 'minute');
+  private _pendingProcesses: Promise<any>[];
   constructor(
     public options?: {
       key?: string
@@ -114,11 +114,17 @@ export class Client {
       limit_price?: number
     }
   }): Promise<Order> {
-    return new Promise<Order>((resolve, reject) =>
+    let transaction = new Promise<Order>((resolve, reject) =>
       this.request(method.POST, URL.Account, `orders`, parameters)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   replaceOrder(parameters: {
@@ -129,7 +135,7 @@ export class Client {
     stop_price?: number
     client_order_id?: string
   }): Promise<Order> {
-    return new Promise<Order>((resolve, reject) =>
+    let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.PATCH,
         URL.Account,
@@ -139,22 +145,37 @@ export class Client {
         .then(resolve)
         .catch(reject)
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   cancelOrder(parameters: { order_id: string }): Promise<Order> {
-    return new Promise<Order>((resolve, reject) =>
+    let transaction = new Promise<Order>((resolve, reject) =>
       this.request(method.DELETE, URL.Account, `orders/${parameters.order_id}`)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   cancelOrders(): Promise<Order[]> {
-    return new Promise<Order[]>((resolve, reject) =>
+    let transaction = new Promise<Order[]>((resolve, reject) =>
       this.request(method.DELETE, URL.Account, `orders`)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   getPosition(parameters: { symbol: string }): Promise<Position[]> {
@@ -174,19 +195,31 @@ export class Client {
   }
 
   closePosition(parameters: { symbol: string }): Promise<Order> {
-    return new Promise<Order>((resolve, reject) =>
+    let transaction = new Promise<Order>((resolve, reject) =>
       this.request(method.DELETE, URL.Account, `positions/${parameters.symbol}`)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   closePositions(): Promise<Order[]> {
-    return new Promise<Order[]>((resolve, reject) =>
+    let transaction = new Promise<Order[]>((resolve, reject) =>
       this.request(method.DELETE, URL.Account, `positions`)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   getAsset(parameters: { asset_id_or_symbol: string }): Promise<Asset> {
@@ -236,11 +269,17 @@ export class Client {
     name: string
     symbols?: string[]
   }): Promise<Watchlist[]> {
-    return new Promise<Watchlist[]>((resolve, reject) =>
+    let transaction = new Promise<Watchlist[]>((resolve, reject) =>
       this.request(method.POST, URL.Account, `watchlists`, parameters)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   updateWatchlist(parameters: {
@@ -248,7 +287,7 @@ export class Client {
     name?: string
     symbols?: string[]
   }): Promise<Watchlist> {
-    return new Promise<Watchlist>((resolve, reject) =>
+    let transaction = new Promise<Watchlist>((resolve, reject) =>
       this.request(
         method.PUT,
         URL.Account,
@@ -257,14 +296,20 @@ export class Client {
       )
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   addToWatchlist(parameters: {
     uuid: string
     symbol: string
   }): Promise<Watchlist> {
-    return new Promise<Watchlist>((resolve, reject) =>
+    let transaction = new Promise<Watchlist>((resolve, reject) =>
       this.request(
         method.POST,
         URL.Account,
@@ -273,14 +318,20 @@ export class Client {
       )
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   removeFromWatchlist(parameters: {
     uuid: string
     symbol: string
   }): Promise<void> {
-    return new Promise<void>((resolve, reject) =>
+    let transaction = new Promise<void>((resolve, reject) =>
       this.request(
         method.DELETE,
         URL.Account,
@@ -288,15 +339,27 @@ export class Client {
       )
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+    
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   deleteWatchlist(parameters: { uuid: string }): Promise<void> {
-    return new Promise<void>((resolve, reject) =>
+    let transaction = new Promise<void>((resolve, reject) =>
       this.request(method.DELETE, URL.Account, `watchlists/${parameters.uuid}`)
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   getCalendar(parameters?: { start?: Date; end?: Date }): Promise<Calendar[]> {
@@ -331,7 +394,7 @@ export class Client {
     suspend_trade?: boolean
     trade_confirm_email?: string
   }): Promise<AccountConfigurations> {
-    return new Promise<AccountConfigurations>((resolve, reject) =>
+    let transaction = new Promise<AccountConfigurations>((resolve, reject) =>
       this.request(
         method.PATCH,
         URL.Account,
@@ -340,7 +403,13 @@ export class Client {
       )
         .then(resolve)
         .catch(reject)
+        .finally(() => {
+          this._pendingProcesses.filter(p => p !== transaction);
+        })
     )
+
+    this._pendingProcesses.push(transaction);
+    return transaction;
   }
 
   getAccountActivities(parameters: {
@@ -431,6 +500,12 @@ export class Client {
         .then(resolve)
         .catch(reject)
     )
+  }
+  
+  //Allows all Promises to complete
+  close(): Promise<void> {
+    return Promise.all(this._pendingProcesses)
+    .then(() => {})
   }
 
   private request(

--- a/test/client.ts
+++ b/test/client.ts
@@ -232,3 +232,10 @@ ava('getLastQuote', async (test) => {
     .then(() => test.pass())
     .catch(test.fail)
 })
+
+ava('close', async (test) => {
+  await client
+    .close()
+    .then(() => test.pass())
+    .catch(() => test.fail())
+})


### PR DESCRIPTION
As I began using this API, I found no way to guarantee an operation completed in the event of `SIGTERM`, or `SIGKILL`. This PR adds the ability to methods that effect resources to be tracked via `this._pendingProcesses`. If a user of this API needs to close the current `Node` process rapidly, we can now guarantee operations performed on resources are completed. 