### PR TITLE
Changed client method parameters to interfaces

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var client_1 = require("./lib/client");
-Object.defineProperty(exports, "Client", { enumerable: true, get: function () { return client_1.Client; } });
+exports.Client = client_1.Client;
 var stream_1 = require("./lib/stream");
-Object.defineProperty(exports, "Stream", { enumerable: true, get: function () { return stream_1.Stream; } });
+exports.Stream = stream_1.Stream;
 var common_1 = require("./lib/common");
-Object.defineProperty(exports, "BaseURL", { enumerable: true, get: function () { return common_1.BaseURL; } });
+exports.BaseURL = common_1.BaseURL;

--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -1,4 +1,123 @@
 import { Account, Order, Position, Asset, Watchlist, Calendar, Clock, AccountConfigurations, TradeActivity, NonTradeActivity, PortfolioHistory, Bar, LastTradeResponse, LastQuoteResponse } from './entities';
+export interface GetOrderOptions {
+    order_id?: string;
+    client_order_id?: string;
+    nested?: boolean;
+}
+export interface GetOrdersOptions {
+    status?: string;
+    limit?: number;
+    after?: Date;
+    until?: Date;
+    direction?: string;
+    nested?: boolean;
+}
+export interface PlaceOrderOptions {
+    symbol: string;
+    qty: number;
+    side: 'buy' | 'sell';
+    type: 'market' | 'limit' | 'stop' | 'stop_limit';
+    time_in_force: 'day' | 'gtc' | 'opg' | 'cls' | 'ioc' | 'fok';
+    limit_price?: number;
+    stop_price?: number;
+    extended_hours?: boolean;
+    client_order_id?: string;
+    order_class?: 'simple' | 'bracket' | 'oco' | 'oto';
+    take_profit?: {
+        limit_price: number;
+    };
+    stop_loss?: {
+        stop_price: number;
+        limit_price?: number;
+    };
+}
+export interface ReplaceOrderOptions {
+    order_id: string;
+    qty?: number;
+    time_in_force?: string;
+    limit_price?: number;
+    stop_price?: number;
+    client_order_id?: string;
+}
+export interface CancelOrderOptions {
+    order_id: string;
+}
+export interface GetPositionOptions {
+    symbol: string;
+}
+export interface ClosePositionOptions {
+    symbol: string;
+}
+export interface GetAssetOptions {
+    asset_id_or_symbol: string;
+}
+export interface GetAssetsOptions {
+    status?: 'active' | 'inactive';
+    asset_class?: string;
+}
+export interface GetWatchListOptions {
+    uuid: string;
+}
+export interface CreateWatchListOptions {
+    name: string;
+    symbols?: string[];
+}
+export interface UpdateWatchListOptions {
+    uuid: string;
+    name?: string;
+    symbols?: string[];
+}
+export interface AddToWatchListOptions {
+    uuid: string;
+    symbol: string;
+}
+export interface RemoveFromWatchListOptions {
+    uuid: string;
+    symbol: string;
+}
+export interface DeleteWatchListOptions {
+    uuid: string;
+}
+export interface GetCalendarOptions {
+    start?: Date;
+    end?: Date;
+}
+export interface UpdateAccountConfigurationsOptions {
+    dtbp_check?: string;
+    no_shorting?: boolean;
+    suspend_trade?: boolean;
+    trade_confirm_email?: string;
+}
+export interface GetAccountActivitiesOptions {
+    activity_type: string;
+    date?: Date;
+    until?: Date;
+    after?: Date;
+    direction?: 'asc' | 'desc';
+    page_size?: number;
+    page_token?: string;
+}
+export interface GetPortfolioHistoryOptions {
+    period?: string;
+    timeframe?: string;
+    date_end?: Date;
+    extended_hours?: boolean;
+}
+export interface GetBarsOptions {
+    timeframe?: string;
+    symbols: string[];
+    limit?: number;
+    start?: Date;
+    end?: Date;
+    after?: Date;
+    until?: Date;
+}
+export interface GetLastTradeOptions {
+    symbol: string;
+}
+export interface GetLastQuoteOptions {
+    symbol: string;
+}
 export declare class Client {
     options?: {
         key?: string;
@@ -15,131 +134,34 @@ export declare class Client {
         rate_limit?: boolean;
     });
     getAccount(): Promise<Account>;
-    getOrder(parameters: {
-        order_id?: string;
-        client_order_id?: string;
-        nested?: boolean;
-    }): Promise<Order>;
-    getOrders(parameters?: {
-        status?: string;
-        limit?: number;
-        after?: Date;
-        until?: Date;
-        direction?: string;
-        nested?: boolean;
-    }): Promise<Order[]>;
-    placeOrder(parameters: {
-        symbol: string;
-        qty: number;
-        side: 'buy' | 'sell';
-        type: 'market' | 'limit' | 'stop' | 'stop_limit';
-        time_in_force: 'day' | 'gtc' | 'opg' | 'cls' | 'ioc' | 'fok';
-        limit_price?: number;
-        stop_price?: number;
-        extended_hours?: boolean;
-        client_order_id?: string;
-        order_class?: 'simple' | 'bracket' | 'oco' | 'oto';
-        take_profit?: {
-            limit_price: number;
-        };
-        stop_loss?: {
-            stop_price: number;
-            limit_price?: number;
-        };
-    }): Promise<Order>;
-    replaceOrder(parameters: {
-        order_id: string;
-        qty?: number;
-        time_in_force?: string;
-        limit_price?: number;
-        stop_price?: number;
-        client_order_id?: string;
-    }): Promise<Order>;
-    cancelOrder(parameters: {
-        order_id: string;
-    }): Promise<Order>;
+    getOrder(parameters: GetOrderOptions): Promise<Order>;
+    getOrders(parameters?: GetOrdersOptions): Promise<Order[]>;
+    placeOrder(parameters: PlaceOrderOptions): Promise<Order>;
+    replaceOrder(parameters: ReplaceOrderOptions): Promise<Order>;
+    cancelOrder(parameters: CancelOrderOptions): Promise<Order>;
     cancelOrders(): Promise<Order[]>;
-    getPosition(parameters: {
-        symbol: string;
-    }): Promise<Position>;
+    getPosition(parameters: GetPositionOptions): Promise<Position>;
     getPositions(): Promise<Position[]>;
-    closePosition(parameters: {
-        symbol: string;
-    }): Promise<Order>;
+    closePosition(parameters: ClosePositionOptions): Promise<Order>;
     closePositions(): Promise<Order[]>;
-    getAsset(parameters: {
-        asset_id_or_symbol: string;
-    }): Promise<Asset>;
-    getAssets(parameters?: {
-        status?: 'active' | 'inactive';
-        asset_class?: string;
-    }): Promise<Asset[]>;
-    getWatchlist(parameters: {
-        uuid: string;
-    }): Promise<Watchlist>;
+    getAsset(parameters: GetAssetOptions): Promise<Asset>;
+    getAssets(parameters?: GetAssetsOptions): Promise<Asset[]>;
+    getWatchlist(parameters: GetWatchListOptions): Promise<Watchlist>;
     getWatchlists(): Promise<Watchlist[]>;
-    createWatchlist(parameters: {
-        name: string;
-        symbols?: string[];
-    }): Promise<Watchlist[]>;
-    updateWatchlist(parameters: {
-        uuid: string;
-        name?: string;
-        symbols?: string[];
-    }): Promise<Watchlist>;
-    addToWatchlist(parameters: {
-        uuid: string;
-        symbol: string;
-    }): Promise<Watchlist>;
-    removeFromWatchlist(parameters: {
-        uuid: string;
-        symbol: string;
-    }): Promise<void>;
-    deleteWatchlist(parameters: {
-        uuid: string;
-    }): Promise<void>;
-    getCalendar(parameters?: {
-        start?: Date;
-        end?: Date;
-    }): Promise<Calendar[]>;
+    createWatchlist(parameters: CreateWatchListOptions): Promise<Watchlist[]>;
+    updateWatchlist(parameters: UpdateWatchListOptions): Promise<Watchlist>;
+    addToWatchlist(parameters: AddToWatchListOptions): Promise<Watchlist>;
+    removeFromWatchlist(parameters: RemoveFromWatchListOptions): Promise<void>;
+    deleteWatchlist(parameters: DeleteWatchListOptions): Promise<void>;
+    getCalendar(parameters?: GetCalendarOptions): Promise<Calendar[]>;
     getClock(): Promise<Clock>;
     getAccountConfigurations(): Promise<AccountConfigurations>;
-    updateAccountConfigurations(parameters: {
-        dtbp_check?: string;
-        no_shorting?: boolean;
-        suspend_trade?: boolean;
-        trade_confirm_email?: string;
-    }): Promise<AccountConfigurations>;
-    getAccountActivities(parameters: {
-        activity_type: string;
-        date?: Date;
-        until?: Date;
-        after?: Date;
-        direction?: 'asc' | 'desc';
-        page_size?: number;
-        page_token?: string;
-    }): Promise<Array<NonTradeActivity | TradeActivity>[]>;
-    getPortfolioHistory(parameters?: {
-        period?: string;
-        timeframe?: string;
-        date_end?: Date;
-        extended_hours?: boolean;
-    }): Promise<PortfolioHistory>;
-    getBars(parameters: {
-        timeframe?: string;
-        symbols: string[];
-        limit?: number;
-        start?: Date;
-        end?: Date;
-        after?: Date;
-        until?: Date;
-    }): Promise<Map<String, Bar[]>>;
-    getLastTrade(parameters: {
-        symbol: string;
-    }): Promise<LastTradeResponse>;
-    getLastQuote(parameters: {
-        symbol: string;
-    }): Promise<LastQuoteResponse>;
+    updateAccountConfigurations(parameters: UpdateAccountConfigurationsOptions): Promise<AccountConfigurations>;
+    getAccountActivities(parameters: GetAccountActivitiesOptions): Promise<Array<NonTradeActivity | TradeActivity>[]>;
+    getPortfolioHistory(parameters?: GetPortfolioHistoryOptions): Promise<PortfolioHistory>;
+    getBars(parameters: GetBarsOptions): Promise<Map<String, Bar[]>>;
+    getLastTrade(parameters: GetLastTradeOptions): Promise<LastTradeResponse>;
+    getLastQuote(parameters: GetLastQuoteOptions): Promise<LastQuoteResponse>;
     close(): Promise<void>;
     private request;
 }

--- a/dist/lib/client.d.ts
+++ b/dist/lib/client.d.ts
@@ -1,10 +1,10 @@
 import { Account, Order, Position, Asset, Watchlist, Calendar, Clock, AccountConfigurations, TradeActivity, NonTradeActivity, PortfolioHistory, Bar, LastTradeResponse, LastQuoteResponse } from './entities';
-export interface GetOrderOptions {
+export interface GetOrderParameters {
     order_id?: string;
     client_order_id?: string;
     nested?: boolean;
 }
-export interface GetOrdersOptions {
+export interface GetOrdersParameters {
     status?: string;
     limit?: number;
     after?: Date;
@@ -12,7 +12,7 @@ export interface GetOrdersOptions {
     direction?: string;
     nested?: boolean;
 }
-export interface PlaceOrderOptions {
+export interface PlaceOrderParameters {
     symbol: string;
     qty: number;
     side: 'buy' | 'sell';
@@ -31,7 +31,7 @@ export interface PlaceOrderOptions {
         limit_price?: number;
     };
 }
-export interface ReplaceOrderOptions {
+export interface ReplaceOrderParameters {
     order_id: string;
     qty?: number;
     time_in_force?: string;
@@ -39,56 +39,56 @@ export interface ReplaceOrderOptions {
     stop_price?: number;
     client_order_id?: string;
 }
-export interface CancelOrderOptions {
+export interface CancelOrderParameters {
     order_id: string;
 }
-export interface GetPositionOptions {
+export interface GetPositionParameters {
     symbol: string;
 }
-export interface ClosePositionOptions {
+export interface ClosePositionParameters {
     symbol: string;
 }
-export interface GetAssetOptions {
+export interface GetAssetParameters {
     asset_id_or_symbol: string;
 }
-export interface GetAssetsOptions {
+export interface GetAssetsParameters {
     status?: 'active' | 'inactive';
     asset_class?: string;
 }
-export interface GetWatchListOptions {
+export interface GetWatchListParameters {
     uuid: string;
 }
-export interface CreateWatchListOptions {
+export interface CreateWatchListParameters {
     name: string;
     symbols?: string[];
 }
-export interface UpdateWatchListOptions {
+export interface UpdateWatchListParameters {
     uuid: string;
     name?: string;
     symbols?: string[];
 }
-export interface AddToWatchListOptions {
+export interface AddToWatchListParameters {
     uuid: string;
     symbol: string;
 }
-export interface RemoveFromWatchListOptions {
+export interface RemoveFromWatchListParameters {
     uuid: string;
     symbol: string;
 }
-export interface DeleteWatchListOptions {
+export interface DeleteWatchListParameters {
     uuid: string;
 }
-export interface GetCalendarOptions {
+export interface GetCalendarParameters {
     start?: Date;
     end?: Date;
 }
-export interface UpdateAccountConfigurationsOptions {
+export interface UpdateAccountConfigurationsParameters {
     dtbp_check?: string;
     no_shorting?: boolean;
     suspend_trade?: boolean;
     trade_confirm_email?: string;
 }
-export interface GetAccountActivitiesOptions {
+export interface GetAccountActivitiesParameters {
     activity_type: string;
     date?: Date;
     until?: Date;
@@ -97,13 +97,13 @@ export interface GetAccountActivitiesOptions {
     page_size?: number;
     page_token?: string;
 }
-export interface GetPortfolioHistoryOptions {
+export interface GetPortfolioHistoryParameters {
     period?: string;
     timeframe?: string;
     date_end?: Date;
     extended_hours?: boolean;
 }
-export interface GetBarsOptions {
+export interface GetBarsParameters {
     timeframe?: string;
     symbols: string[];
     limit?: number;
@@ -112,10 +112,10 @@ export interface GetBarsOptions {
     after?: Date;
     until?: Date;
 }
-export interface GetLastTradeOptions {
+export interface GetLastTradeParameters {
     symbol: string;
 }
-export interface GetLastQuoteOptions {
+export interface GetLastQuoteParameters {
     symbol: string;
 }
 export declare class Client {
@@ -134,34 +134,34 @@ export declare class Client {
         rate_limit?: boolean;
     });
     getAccount(): Promise<Account>;
-    getOrder(parameters: GetOrderOptions): Promise<Order>;
-    getOrders(parameters?: GetOrdersOptions): Promise<Order[]>;
-    placeOrder(parameters: PlaceOrderOptions): Promise<Order>;
-    replaceOrder(parameters: ReplaceOrderOptions): Promise<Order>;
-    cancelOrder(parameters: CancelOrderOptions): Promise<Order>;
+    getOrder(parameters: GetOrderParameters): Promise<Order>;
+    getOrders(parameters?: GetOrdersParameters): Promise<Order[]>;
+    placeOrder(parameters: PlaceOrderParameters): Promise<Order>;
+    replaceOrder(parameters: ReplaceOrderParameters): Promise<Order>;
+    cancelOrder(parameters: CancelOrderParameters): Promise<Order>;
     cancelOrders(): Promise<Order[]>;
-    getPosition(parameters: GetPositionOptions): Promise<Position>;
+    getPosition(parameters: GetPositionParameters): Promise<Position>;
     getPositions(): Promise<Position[]>;
-    closePosition(parameters: ClosePositionOptions): Promise<Order>;
+    closePosition(parameters: ClosePositionParameters): Promise<Order>;
     closePositions(): Promise<Order[]>;
-    getAsset(parameters: GetAssetOptions): Promise<Asset>;
-    getAssets(parameters?: GetAssetsOptions): Promise<Asset[]>;
-    getWatchlist(parameters: GetWatchListOptions): Promise<Watchlist>;
+    getAsset(parameters: GetAssetParameters): Promise<Asset>;
+    getAssets(parameters?: GetAssetsParameters): Promise<Asset[]>;
+    getWatchlist(parameters: GetWatchListParameters): Promise<Watchlist>;
     getWatchlists(): Promise<Watchlist[]>;
-    createWatchlist(parameters: CreateWatchListOptions): Promise<Watchlist[]>;
-    updateWatchlist(parameters: UpdateWatchListOptions): Promise<Watchlist>;
-    addToWatchlist(parameters: AddToWatchListOptions): Promise<Watchlist>;
-    removeFromWatchlist(parameters: RemoveFromWatchListOptions): Promise<void>;
-    deleteWatchlist(parameters: DeleteWatchListOptions): Promise<void>;
-    getCalendar(parameters?: GetCalendarOptions): Promise<Calendar[]>;
+    createWatchlist(parameters: CreateWatchListParameters): Promise<Watchlist[]>;
+    updateWatchlist(parameters: UpdateWatchListParameters): Promise<Watchlist>;
+    addToWatchlist(parameters: AddToWatchListParameters): Promise<Watchlist>;
+    removeFromWatchlist(parameters: RemoveFromWatchListParameters): Promise<void>;
+    deleteWatchlist(parameters: DeleteWatchListParameters): Promise<void>;
+    getCalendar(parameters?: GetCalendarParameters): Promise<Calendar[]>;
     getClock(): Promise<Clock>;
     getAccountConfigurations(): Promise<AccountConfigurations>;
-    updateAccountConfigurations(parameters: UpdateAccountConfigurationsOptions): Promise<AccountConfigurations>;
-    getAccountActivities(parameters: GetAccountActivitiesOptions): Promise<Array<NonTradeActivity | TradeActivity>[]>;
-    getPortfolioHistory(parameters?: GetPortfolioHistoryOptions): Promise<PortfolioHistory>;
-    getBars(parameters: GetBarsOptions): Promise<Map<String, Bar[]>>;
-    getLastTrade(parameters: GetLastTradeOptions): Promise<LastTradeResponse>;
-    getLastQuote(parameters: GetLastQuoteOptions): Promise<LastQuoteResponse>;
+    updateAccountConfigurations(parameters: UpdateAccountConfigurationsParameters): Promise<AccountConfigurations>;
+    getAccountActivities(parameters: GetAccountActivitiesParameters): Promise<Array<NonTradeActivity | TradeActivity>[]>;
+    getPortfolioHistory(parameters?: GetPortfolioHistoryParameters): Promise<PortfolioHistory>;
+    getBars(parameters: GetBarsParameters): Promise<Map<String, Bar[]>>;
+    getLastTrade(parameters: GetLastTradeParameters): Promise<LastTradeResponse>;
+    getLastQuote(parameters: GetLastQuoteParameters): Promise<LastQuoteResponse>;
     close(): Promise<void>;
     private request;
 }

--- a/dist/lib/client.js
+++ b/dist/lib/client.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Client = void 0;
 const node_fetch_1 = __importDefault(require("node-fetch"));
 const http_method_enum_1 = __importDefault(require("http-method-enum"));
 const qs_1 = __importDefault(require("qs"));

--- a/dist/lib/common.js
+++ b/dist/lib/common.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.BaseURL = void 0;
 var BaseURL;
 (function (BaseURL) {
     BaseURL["Account"] = "https://api.alpaca.markets/v2";

--- a/dist/lib/entities.js
+++ b/dist/lib/entities.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.WebSocketState = void 0;
 var WebSocketState;
 (function (WebSocketState) {
     WebSocketState["NOT_CONNECTED"] = "not_connected";

--- a/dist/lib/stream.js
+++ b/dist/lib/stream.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Stream = void 0;
 const ws_1 = __importDefault(require("ws"));
 const entities_1 = require("./entities");
 class Stream {

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -22,6 +22,147 @@ import {
   LastQuoteResponse,
 } from './entities'
 
+export interface GetOrderOptions {
+  order_id?: string
+  client_order_id?: string
+  nested?: boolean
+}
+
+export interface GetOrdersOptions {
+  status?: string
+  limit?: number
+  after?: Date
+  until?: Date
+  direction?: string
+  nested?: boolean
+}
+
+export interface PlaceOrderOptions {
+  symbol: string
+  qty: number
+  side: 'buy' | 'sell'
+  type: 'market' | 'limit' | 'stop' | 'stop_limit'
+  time_in_force: 'day' | 'gtc' | 'opg' | 'cls' | 'ioc' | 'fok'
+  limit_price?: number
+  stop_price?: number
+  extended_hours?: boolean
+  client_order_id?: string
+  order_class?: 'simple' | 'bracket' | 'oco' | 'oto'
+  take_profit?: {
+    limit_price: number
+  }
+  stop_loss?: {
+    stop_price: number
+    limit_price?: number
+  }
+}
+
+export interface ReplaceOrderOptions {
+  order_id: string
+  qty?: number
+  time_in_force?: string
+  limit_price?: number
+  stop_price?: number
+  client_order_id?: string
+}
+
+export interface CancelOrderOptions {
+  order_id: string
+}
+
+export interface GetPositionOptions {
+  symbol: string
+} 
+
+export interface ClosePositionOptions {
+  symbol: string
+}
+
+export interface GetAssetOptions {
+  asset_id_or_symbol: string
+}
+
+export interface GetAssetsOptions {
+  status?: 'active' | 'inactive'
+  asset_class?: string // i don't know where to find all asset classes
+}
+
+export interface GetWatchListOptions {
+  uuid: string
+}
+
+export interface CreateWatchListOptions {
+  name: string
+  symbols?: string[]
+}
+
+export interface UpdateWatchListOptions {
+  uuid: string
+  name?: string
+  symbols?: string[]
+}
+
+export interface AddToWatchListOptions {
+  uuid: string
+  symbol: string
+}
+
+export interface RemoveFromWatchListOptions {
+  uuid: string
+  symbol: string
+}
+
+export interface DeleteWatchListOptions {
+  uuid: string
+}
+
+export interface GetCalendarOptions {
+  start?: Date
+  end?: Date
+}
+
+export interface UpdateAccountConfigurationsOptions {
+  dtbp_check?: string
+  no_shorting?: boolean
+  suspend_trade?: boolean
+  trade_confirm_email?: string
+}
+
+export interface GetAccountActivitiesOptions {
+  activity_type: string
+  date?: Date
+  until?: Date
+  after?: Date
+  direction?: 'asc' | 'desc'
+  page_size?: number
+  page_token?: string
+}
+
+export interface GetPortfolioHistoryOptions {
+  period?: string
+  timeframe?: string
+  date_end?: Date
+  extended_hours?: boolean
+}
+
+export interface GetBarsOptions {
+  timeframe?: string
+  symbols: string[]
+  limit?: number
+  start?: Date
+  end?: Date
+  after?: Date
+  until?: Date
+}
+
+export interface GetLastTradeOptions {
+  symbol: string
+}
+
+export interface GetLastQuoteOptions {
+  symbol: string
+}
+
 export class Client {
   private limiter: RateLimiter = new RateLimiter(199, 'minute')
   private pendingPromises: Promise<any>[] = []
@@ -57,11 +198,7 @@ export class Client {
     )
   }
 
-  getOrder(parameters: {
-    order_id?: string
-    client_order_id?: string
-    nested?: boolean
-  }): Promise<Order> {
+  getOrder(parameters: GetOrderOptions): Promise<Order> {
     return new Promise<Order>((resolve, reject) =>
       this.request(
         method.GET,
@@ -77,14 +214,7 @@ export class Client {
     )
   }
 
-  getOrders(parameters?: {
-    status?: string
-    limit?: number
-    after?: Date
-    until?: Date
-    direction?: string
-    nested?: boolean
-  }): Promise<Order[]> {
+  getOrders(parameters?: GetOrdersOptions): Promise<Order[]> {
     return new Promise<Order[]>((resolve, reject) =>
       this.request(
         method.GET,
@@ -96,25 +226,7 @@ export class Client {
     )
   }
 
-  placeOrder(parameters: {
-    symbol: string
-    qty: number
-    side: 'buy' | 'sell'
-    type: 'market' | 'limit' | 'stop' | 'stop_limit'
-    time_in_force: 'day' | 'gtc' | 'opg' | 'cls' | 'ioc' | 'fok'
-    limit_price?: number
-    stop_price?: number
-    extended_hours?: boolean
-    client_order_id?: string
-    order_class?: 'simple' | 'bracket' | 'oco' | 'oto'
-    take_profit?: {
-      limit_price: number
-    }
-    stop_loss?: {
-      stop_price: number
-      limit_price?: number
-    }
-  }): Promise<Order> {
+  placeOrder(parameters: PlaceOrderOptions): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(method.POST, BaseURL.Account, `orders`, parameters)
         .then(resolve)
@@ -130,14 +242,7 @@ export class Client {
     return transaction
   }
 
-  replaceOrder(parameters: {
-    order_id: string
-    qty?: number
-    time_in_force?: string
-    limit_price?: number
-    stop_price?: number
-    client_order_id?: string
-  }): Promise<Order> {
+  replaceOrder(parameters: ReplaceOrderOptions): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.PATCH,
@@ -153,7 +258,7 @@ export class Client {
     return transaction
   }
 
-  cancelOrder(parameters: { order_id: string }): Promise<Order> {
+  cancelOrder(parameters: CancelOrderOptions): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -189,7 +294,7 @@ export class Client {
     return transaction
   }
 
-  getPosition(parameters: { symbol: string }): Promise<Position> {
+  getPosition(parameters: GetPositionOptions): Promise<Position> {
     return new Promise<Position>((resolve, reject) =>
       this.request(
         method.GET,
@@ -209,7 +314,7 @@ export class Client {
     )
   }
 
-  closePosition(parameters: { symbol: string }): Promise<Order> {
+  closePosition(parameters: ClosePositionOptions): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -245,7 +350,7 @@ export class Client {
     return transaction
   }
 
-  getAsset(parameters: { asset_id_or_symbol: string }): Promise<Asset> {
+  getAsset(parameters: GetAssetOptions): Promise<Asset> {
     return new Promise<Asset>((resolve, reject) =>
       this.request(
         method.GET,
@@ -257,10 +362,7 @@ export class Client {
     )
   }
 
-  getAssets(parameters?: {
-    status?: 'active' | 'inactive'
-    asset_class?: string // i don't know where to find all asset classes
-  }): Promise<Asset[]> {
+  getAssets(parameters?: GetAssetsOptions): Promise<Asset[]> {
     return new Promise<Asset[]>((resolve, reject) =>
       this.request(
         method.GET,
@@ -272,7 +374,7 @@ export class Client {
     )
   }
 
-  getWatchlist(parameters: { uuid: string }): Promise<Watchlist> {
+  getWatchlist(parameters: GetWatchListOptions): Promise<Watchlist> {
     return new Promise<Watchlist>((resolve, reject) =>
       this.request(method.GET, BaseURL.Account, `watchlists/${parameters.uuid}`)
         .then(resolve)
@@ -288,10 +390,7 @@ export class Client {
     )
   }
 
-  createWatchlist(parameters: {
-    name: string
-    symbols?: string[]
-  }): Promise<Watchlist[]> {
+  createWatchlist(parameters: CreateWatchListOptions): Promise<Watchlist[]> {
     let transaction = new Promise<Watchlist[]>((resolve, reject) =>
       this.request(method.POST, BaseURL.Account, `watchlists`, parameters)
         .then(resolve)
@@ -307,11 +406,7 @@ export class Client {
     return transaction
   }
 
-  updateWatchlist(parameters: {
-    uuid: string
-    name?: string
-    symbols?: string[]
-  }): Promise<Watchlist> {
+  updateWatchlist(parameters: UpdateWatchListOptions): Promise<Watchlist> {
     let transaction = new Promise<Watchlist>((resolve, reject) =>
       this.request(
         method.PUT,
@@ -332,10 +427,7 @@ export class Client {
     return transaction
   }
 
-  addToWatchlist(parameters: {
-    uuid: string
-    symbol: string
-  }): Promise<Watchlist> {
+  addToWatchlist(parameters: AddToWatchListOptions): Promise<Watchlist> {
     let transaction = new Promise<Watchlist>((resolve, reject) =>
       this.request(
         method.POST,
@@ -356,10 +448,7 @@ export class Client {
     return transaction
   }
 
-  removeFromWatchlist(parameters: {
-    uuid: string
-    symbol: string
-  }): Promise<void> {
+  removeFromWatchlist(parameters: RemoveFromWatchListOptions): Promise<void> {
     let transaction = new Promise<void>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -379,7 +468,7 @@ export class Client {
     return transaction
   }
 
-  deleteWatchlist(parameters: { uuid: string }): Promise<void> {
+  deleteWatchlist(parameters: DeleteWatchListOptions): Promise<void> {
     let transaction = new Promise<void>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -399,7 +488,7 @@ export class Client {
     return transaction
   }
 
-  getCalendar(parameters?: { start?: Date; end?: Date }): Promise<Calendar[]> {
+  getCalendar(parameters?: GetCalendarOptions): Promise<Calendar[]> {
     return new Promise<Calendar[]>((resolve, reject) =>
       this.request(
         method.GET,
@@ -427,12 +516,7 @@ export class Client {
     )
   }
 
-  updateAccountConfigurations(parameters: {
-    dtbp_check?: string
-    no_shorting?: boolean
-    suspend_trade?: boolean
-    trade_confirm_email?: string
-  }): Promise<AccountConfigurations> {
+  updateAccountConfigurations(parameters: UpdateAccountConfigurationsOptions): Promise<AccountConfigurations> {
     let transaction = new Promise<AccountConfigurations>((resolve, reject) =>
       this.request(
         method.PATCH,
@@ -453,15 +537,7 @@ export class Client {
     return transaction
   }
 
-  getAccountActivities(parameters: {
-    activity_type: string
-    date?: Date
-    until?: Date
-    after?: Date
-    direction?: 'asc' | 'desc'
-    page_size?: number
-    page_token?: string
-  }): Promise<Array<NonTradeActivity | TradeActivity>[]> {
+  getAccountActivities(parameters: GetAccountActivitiesOptions): Promise<Array<NonTradeActivity | TradeActivity>[]> {
     return new Promise<Array<NonTradeActivity | TradeActivity>[]>(
       (resolve, reject) =>
         this.request(
@@ -476,12 +552,7 @@ export class Client {
     )
   }
 
-  getPortfolioHistory(parameters?: {
-    period?: string
-    timeframe?: string
-    date_end?: Date
-    extended_hours?: boolean
-  }): Promise<PortfolioHistory> {
+  getPortfolioHistory(parameters?: GetPortfolioHistoryOptions): Promise<PortfolioHistory> {
     return new Promise<PortfolioHistory>((resolve, reject) =>
       this.request(
         method.GET,
@@ -493,15 +564,7 @@ export class Client {
     )
   }
 
-  getBars(parameters: {
-    timeframe?: string
-    symbols: string[]
-    limit?: number
-    start?: Date
-    end?: Date
-    after?: Date
-    until?: Date
-  }): Promise<Map<String, Bar[]>> {
+  getBars(parameters: GetBarsOptions): Promise<Map<String, Bar[]>> {
     var transformed = {}
 
     // join the symbols into a comma-delimited string
@@ -519,7 +582,7 @@ export class Client {
     )
   }
 
-  getLastTrade(parameters: { symbol: string }): Promise<LastTradeResponse> {
+  getLastTrade(parameters: GetLastTradeOptions): Promise<LastTradeResponse> {
     return new Promise<LastTradeResponse>((resolve, reject) =>
       this.request(
         method.GET,
@@ -531,7 +594,7 @@ export class Client {
     )
   }
 
-  getLastQuote(parameters: { symbol: string }): Promise<LastQuoteResponse> {
+  getLastQuote(parameters: GetLastQuoteOptions): Promise<LastQuoteResponse> {
     return new Promise<LastQuoteResponse>((resolve, reject) =>
       this.request(
         method.GET,

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -22,13 +22,13 @@ import {
   LastQuoteResponse,
 } from './entities'
 
-export interface GetOrderOptions {
+export interface GetOrderParameters {
   order_id?: string
   client_order_id?: string
   nested?: boolean
 }
 
-export interface GetOrdersOptions {
+export interface GetOrdersParameters {
   status?: string
   limit?: number
   after?: Date
@@ -37,7 +37,7 @@ export interface GetOrdersOptions {
   nested?: boolean
 }
 
-export interface PlaceOrderOptions {
+export interface PlaceOrderParameters {
   symbol: string
   qty: number
   side: 'buy' | 'sell'
@@ -57,7 +57,7 @@ export interface PlaceOrderOptions {
   }
 }
 
-export interface ReplaceOrderOptions {
+export interface ReplaceOrderParameters {
   order_id: string
   qty?: number
   time_in_force?: string
@@ -66,69 +66,69 @@ export interface ReplaceOrderOptions {
   client_order_id?: string
 }
 
-export interface CancelOrderOptions {
+export interface CancelOrderParameters {
   order_id: string
 }
 
-export interface GetPositionOptions {
+export interface GetPositionParameters {
   symbol: string
 } 
 
-export interface ClosePositionOptions {
+export interface ClosePositionParameters {
   symbol: string
 }
 
-export interface GetAssetOptions {
+export interface GetAssetParameters {
   asset_id_or_symbol: string
 }
 
-export interface GetAssetsOptions {
+export interface GetAssetsParameters {
   status?: 'active' | 'inactive'
   asset_class?: string // i don't know where to find all asset classes
 }
 
-export interface GetWatchListOptions {
+export interface GetWatchListParameters {
   uuid: string
 }
 
-export interface CreateWatchListOptions {
+export interface CreateWatchListParameters {
   name: string
   symbols?: string[]
 }
 
-export interface UpdateWatchListOptions {
+export interface UpdateWatchListParameters {
   uuid: string
   name?: string
   symbols?: string[]
 }
 
-export interface AddToWatchListOptions {
+export interface AddToWatchListParameters {
   uuid: string
   symbol: string
 }
 
-export interface RemoveFromWatchListOptions {
+export interface RemoveFromWatchListParameters {
   uuid: string
   symbol: string
 }
 
-export interface DeleteWatchListOptions {
+export interface DeleteWatchListParameters {
   uuid: string
 }
 
-export interface GetCalendarOptions {
+export interface GetCalendarParameters {
   start?: Date
   end?: Date
 }
 
-export interface UpdateAccountConfigurationsOptions {
+export interface UpdateAccountConfigurationsParameters {
   dtbp_check?: string
   no_shorting?: boolean
   suspend_trade?: boolean
   trade_confirm_email?: string
 }
 
-export interface GetAccountActivitiesOptions {
+export interface GetAccountActivitiesParameters {
   activity_type: string
   date?: Date
   until?: Date
@@ -138,14 +138,14 @@ export interface GetAccountActivitiesOptions {
   page_token?: string
 }
 
-export interface GetPortfolioHistoryOptions {
+export interface GetPortfolioHistoryParameters {
   period?: string
   timeframe?: string
   date_end?: Date
   extended_hours?: boolean
 }
 
-export interface GetBarsOptions {
+export interface GetBarsParameters {
   timeframe?: string
   symbols: string[]
   limit?: number
@@ -155,11 +155,11 @@ export interface GetBarsOptions {
   until?: Date
 }
 
-export interface GetLastTradeOptions {
+export interface GetLastTradeParameters {
   symbol: string
 }
 
-export interface GetLastQuoteOptions {
+export interface GetLastQuoteParameters {
   symbol: string
 }
 
@@ -198,7 +198,7 @@ export class Client {
     )
   }
 
-  getOrder(parameters: GetOrderOptions): Promise<Order> {
+  getOrder(parameters: GetOrderParameters): Promise<Order> {
     return new Promise<Order>((resolve, reject) =>
       this.request(
         method.GET,
@@ -214,7 +214,7 @@ export class Client {
     )
   }
 
-  getOrders(parameters?: GetOrdersOptions): Promise<Order[]> {
+  getOrders(parameters?: GetOrdersParameters): Promise<Order[]> {
     return new Promise<Order[]>((resolve, reject) =>
       this.request(
         method.GET,
@@ -226,7 +226,7 @@ export class Client {
     )
   }
 
-  placeOrder(parameters: PlaceOrderOptions): Promise<Order> {
+  placeOrder(parameters: PlaceOrderParameters): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(method.POST, BaseURL.Account, `orders`, parameters)
         .then(resolve)
@@ -242,7 +242,7 @@ export class Client {
     return transaction
   }
 
-  replaceOrder(parameters: ReplaceOrderOptions): Promise<Order> {
+  replaceOrder(parameters: ReplaceOrderParameters): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.PATCH,
@@ -258,7 +258,7 @@ export class Client {
     return transaction
   }
 
-  cancelOrder(parameters: CancelOrderOptions): Promise<Order> {
+  cancelOrder(parameters: CancelOrderParameters): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -294,7 +294,7 @@ export class Client {
     return transaction
   }
 
-  getPosition(parameters: GetPositionOptions): Promise<Position> {
+  getPosition(parameters: GetPositionParameters): Promise<Position> {
     return new Promise<Position>((resolve, reject) =>
       this.request(
         method.GET,
@@ -314,7 +314,7 @@ export class Client {
     )
   }
 
-  closePosition(parameters: ClosePositionOptions): Promise<Order> {
+  closePosition(parameters: ClosePositionParameters): Promise<Order> {
     let transaction = new Promise<Order>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -350,7 +350,7 @@ export class Client {
     return transaction
   }
 
-  getAsset(parameters: GetAssetOptions): Promise<Asset> {
+  getAsset(parameters: GetAssetParameters): Promise<Asset> {
     return new Promise<Asset>((resolve, reject) =>
       this.request(
         method.GET,
@@ -362,7 +362,7 @@ export class Client {
     )
   }
 
-  getAssets(parameters?: GetAssetsOptions): Promise<Asset[]> {
+  getAssets(parameters?: GetAssetsParameters): Promise<Asset[]> {
     return new Promise<Asset[]>((resolve, reject) =>
       this.request(
         method.GET,
@@ -374,7 +374,7 @@ export class Client {
     )
   }
 
-  getWatchlist(parameters: GetWatchListOptions): Promise<Watchlist> {
+  getWatchlist(parameters: GetWatchListParameters): Promise<Watchlist> {
     return new Promise<Watchlist>((resolve, reject) =>
       this.request(method.GET, BaseURL.Account, `watchlists/${parameters.uuid}`)
         .then(resolve)
@@ -390,7 +390,7 @@ export class Client {
     )
   }
 
-  createWatchlist(parameters: CreateWatchListOptions): Promise<Watchlist[]> {
+  createWatchlist(parameters: CreateWatchListParameters): Promise<Watchlist[]> {
     let transaction = new Promise<Watchlist[]>((resolve, reject) =>
       this.request(method.POST, BaseURL.Account, `watchlists`, parameters)
         .then(resolve)
@@ -406,7 +406,7 @@ export class Client {
     return transaction
   }
 
-  updateWatchlist(parameters: UpdateWatchListOptions): Promise<Watchlist> {
+  updateWatchlist(parameters: UpdateWatchListParameters): Promise<Watchlist> {
     let transaction = new Promise<Watchlist>((resolve, reject) =>
       this.request(
         method.PUT,
@@ -427,7 +427,7 @@ export class Client {
     return transaction
   }
 
-  addToWatchlist(parameters: AddToWatchListOptions): Promise<Watchlist> {
+  addToWatchlist(parameters: AddToWatchListParameters): Promise<Watchlist> {
     let transaction = new Promise<Watchlist>((resolve, reject) =>
       this.request(
         method.POST,
@@ -448,7 +448,7 @@ export class Client {
     return transaction
   }
 
-  removeFromWatchlist(parameters: RemoveFromWatchListOptions): Promise<void> {
+  removeFromWatchlist(parameters: RemoveFromWatchListParameters): Promise<void> {
     let transaction = new Promise<void>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -468,7 +468,7 @@ export class Client {
     return transaction
   }
 
-  deleteWatchlist(parameters: DeleteWatchListOptions): Promise<void> {
+  deleteWatchlist(parameters: DeleteWatchListParameters): Promise<void> {
     let transaction = new Promise<void>((resolve, reject) =>
       this.request(
         method.DELETE,
@@ -488,7 +488,7 @@ export class Client {
     return transaction
   }
 
-  getCalendar(parameters?: GetCalendarOptions): Promise<Calendar[]> {
+  getCalendar(parameters?: GetCalendarParameters): Promise<Calendar[]> {
     return new Promise<Calendar[]>((resolve, reject) =>
       this.request(
         method.GET,
@@ -516,7 +516,7 @@ export class Client {
     )
   }
 
-  updateAccountConfigurations(parameters: UpdateAccountConfigurationsOptions): Promise<AccountConfigurations> {
+  updateAccountConfigurations(parameters: UpdateAccountConfigurationsParameters): Promise<AccountConfigurations> {
     let transaction = new Promise<AccountConfigurations>((resolve, reject) =>
       this.request(
         method.PATCH,
@@ -537,7 +537,7 @@ export class Client {
     return transaction
   }
 
-  getAccountActivities(parameters: GetAccountActivitiesOptions): Promise<Array<NonTradeActivity | TradeActivity>[]> {
+  getAccountActivities(parameters: GetAccountActivitiesParameters): Promise<Array<NonTradeActivity | TradeActivity>[]> {
     return new Promise<Array<NonTradeActivity | TradeActivity>[]>(
       (resolve, reject) =>
         this.request(
@@ -552,7 +552,7 @@ export class Client {
     )
   }
 
-  getPortfolioHistory(parameters?: GetPortfolioHistoryOptions): Promise<PortfolioHistory> {
+  getPortfolioHistory(parameters?: GetPortfolioHistoryParameters): Promise<PortfolioHistory> {
     return new Promise<PortfolioHistory>((resolve, reject) =>
       this.request(
         method.GET,
@@ -564,7 +564,7 @@ export class Client {
     )
   }
 
-  getBars(parameters: GetBarsOptions): Promise<Map<String, Bar[]>> {
+  getBars(parameters: GetBarsParameters): Promise<Map<String, Bar[]>> {
     var transformed = {}
 
     // join the symbols into a comma-delimited string
@@ -582,7 +582,7 @@ export class Client {
     )
   }
 
-  getLastTrade(parameters: GetLastTradeOptions): Promise<LastTradeResponse> {
+  getLastTrade(parameters: GetLastTradeParameters): Promise<LastTradeResponse> {
     return new Promise<LastTradeResponse>((resolve, reject) =>
       this.request(
         method.GET,
@@ -594,7 +594,7 @@ export class Client {
     )
   }
 
-  getLastQuote(parameters: GetLastQuoteOptions): Promise<LastQuoteResponse> {
+  getLastQuote(parameters: GetLastQuoteParameters): Promise<LastQuoteResponse> {
     return new Promise<LastQuoteResponse>((resolve, reject) =>
       this.request(
         method.GET,


### PR DESCRIPTION
Because of the way the parameters were set up, there cannot be an abstract interface from this client. This adds the options as interfaces, so they can be referenced if an abstract class is created as I needed.

Note: If you'd like these interfaces in a separate file, or interface names changed, let me know and I will make those changes.